### PR TITLE
Fail if not include correct URL

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -19,10 +19,11 @@ type CLI struct {
 	csvpath string
 
 	// options
-	urlRow      int
-	nameRow     int
-	categoryRow int
-	withHeader  bool
+	urlRow       int
+	nameRow      int
+	categoryRow  int
+	categoryName string
+	withHeader   bool
 }
 
 func NewCLI(args []string) (*CLI, error) {
@@ -37,6 +38,7 @@ func NewCLI(args []string) (*CLI, error) {
 	flagset.IntVar(&cli.urlRow, "urlrow", 6, "URL row")
 	flagset.IntVar(&cli.nameRow, "namerow", 1, "name row")
 	flagset.IntVar(&cli.categoryRow, "categoryrow", 0, "category row")
+	flagset.StringVar(&cli.categoryName, "categoryname", "Devquiz枠", "surveyed category name")
 	if err := flagset.Parse(args); err != nil {
 		return nil, errors.Wrap(err, "NewCLI")
 	}
@@ -70,7 +72,7 @@ func (cli *CLI) Run() error {
 		cr.Read() // skip
 	}
 
-	v := NewValidator(cr, cli.urlRow, cli.nameRow, cli.categoryRow)
+	v := NewValidator(cr, cli.urlRow, cli.nameRow, cli.categoryRow, cli.categoryName)
 
 LOOP:
 	for i := 1; v.Next(); i++ {

--- a/cli.go
+++ b/cli.go
@@ -19,9 +19,10 @@ type CLI struct {
 	csvpath string
 
 	// options
-	urlRow     int
-	nameRow    int
-	withHeader bool
+	urlRow      int
+	nameRow     int
+	categoryRow int
+	withHeader  bool
 }
 
 func NewCLI(args []string) (*CLI, error) {
@@ -35,6 +36,7 @@ func NewCLI(args []string) (*CLI, error) {
 	flagset.BoolVar(&cli.withHeader, "withheader", false, "with header")
 	flagset.IntVar(&cli.urlRow, "urlrow", 6, "URL row")
 	flagset.IntVar(&cli.nameRow, "namerow", 1, "name row")
+	flagset.IntVar(&cli.categoryRow, "categoryrow", 0, "category row")
 	if err := flagset.Parse(args); err != nil {
 		return nil, errors.Wrap(err, "NewCLI")
 	}
@@ -68,10 +70,15 @@ func (cli *CLI) Run() error {
 		cr.Read() // skip
 	}
 
-	v := NewValidator(cr, cli.urlRow, cli.nameRow)
+	v := NewValidator(cr, cli.urlRow, cli.nameRow, cli.categoryRow)
 
 LOOP:
 	for i := 1; v.Next(); i++ {
+
+		if err := v.Err(); err != nil {
+			fmt.Printf("%d %s failed(%q)\n", i, v.Name(), err)
+			continue LOOP
+		}
 
 		if v.Result() == nil {
 			fmt.Println(i, "skip")

--- a/validator.go
+++ b/validator.go
@@ -14,22 +14,24 @@ import (
 type Validator struct {
 	HTTPClient *http.Client
 
-	r           *csv.Reader
-	nameRow     int
-	urlRow      int
-	categoryRow int
+	r            *csv.Reader
+	nameRow      int
+	urlRow       int
+	categoryRow  int
+	categoryName string
 
 	name   string
 	result *goplayground.RunResult
 	err    error
 }
 
-func NewValidator(r *csv.Reader, urlRow, nameRow, categoryRow int) *Validator {
+func NewValidator(r *csv.Reader, urlRow, nameRow, categoryRow int, categoryName string) *Validator {
 	return &Validator{
-		r:           r,
-		urlRow:      urlRow,
-		nameRow:     nameRow,
-		categoryRow: categoryRow,
+		r:            r,
+		urlRow:       urlRow,
+		nameRow:      nameRow,
+		categoryRow:  categoryRow,
+		categoryName: categoryName,
 	}
 }
 
@@ -53,6 +55,10 @@ func (v *Validator) Next() bool {
 		return false
 	}
 
+	if v.categoryName != record[v.categoryRow] {
+		return true
+	}
+
 	if v.urlRow < 0 || len(record) <= v.nameRow {
 		v.err = errors.Errorf("invalid nameRow %d", v.nameRow)
 		return false
@@ -65,10 +71,8 @@ func (v *Validator) Next() bool {
 
 	url := record[v.urlRow]
 	if url == "" || !strings.HasPrefix(url, goplayground.BaseURL) {
-		if record[v.categoryRow] == "Devquiz枠" {
-			v.name = record[v.nameRow]
-			v.err = errors.New("cannot get URL")
-		}
+		v.name = record[v.nameRow]
+		v.err = errors.New("cannot get URL")
 		return true
 	}
 

--- a/validator.go
+++ b/validator.go
@@ -14,20 +14,22 @@ import (
 type Validator struct {
 	HTTPClient *http.Client
 
-	r       *csv.Reader
-	nameRow int
-	urlRow  int
+	r           *csv.Reader
+	nameRow     int
+	urlRow      int
+	categoryRow int
 
 	name   string
 	result *goplayground.RunResult
 	err    error
 }
 
-func NewValidator(r *csv.Reader, urlRow, nameRow int) *Validator {
+func NewValidator(r *csv.Reader, urlRow, nameRow, categoryRow int) *Validator {
 	return &Validator{
-		r:       r,
-		urlRow:  urlRow,
-		nameRow: nameRow,
+		r:           r,
+		urlRow:      urlRow,
+		nameRow:     nameRow,
+		categoryRow: categoryRow,
 	}
 }
 
@@ -63,6 +65,10 @@ func (v *Validator) Next() bool {
 
 	url := record[v.urlRow]
 	if url == "" || !strings.HasPrefix(url, goplayground.BaseURL) {
+		if record[v.categoryRow] == "Devquiz枠" {
+			v.name = record[v.nameRow]
+			v.err = errors.New("cannot get URL")
+		}
 		return true
 	}
 


### PR DESCRIPTION
`Devquiz枠`で参加、かつ`Devquizの答え`欄のパースに失敗したエントリーはエラーにするようにしました。


## 動作確認
以下のエントリーのCSVで挙動を確認しました。
- 一般参加枠(正しいplayground URLなし)
- Devquiz枠(正しいplayground URLなし)
- Devquiz枠(正しいplayground URLあり)

```
$ cat ~/Desktop/golang.csv
参加枠名,ユーザー名,表示名,コメント,参加ステータス,出欠ステータス,未成年 or 成人,アルコールを提供するため、当日の受付で年齢の確認できる身分証をご提示いただけますか？,未成年の場合保護者の同意書を受付でご提出いただけますか？,イベントページの注意事項をご確認いただけましたでしょうか？,Devquizの答え,更新日時,受付番号
一般参加枠,skip_entry,skip_entry,golang.tokyo #XXに参加を申し込みました！,参加,,成人,持参することを同意します,未成年ではありません,内容を確認し同意しました,,2018年1月1日 17時00分,8888888
Devquiz枠,ng_entry,ng_entry,golang.tokyo #XX に参加を申し込みました！,補欠,,成人,持参することを同意します,未成年ではありません,内容を確認し同意しました,"invalid URL",2018年1月1日 14時00分,9999999
Devquiz枠,ok_entry,ok_entry,I joined golang.tokyo,補欠,,成人,持参することを同意します,未成年ではありません,内容を確認し同意しました,https://play.golang.org/p/HmnNoBf0p1z,2018年1月1日 03時00分,2222222
```

```bash
$ go run *.go -urlrow 10 ~/Desktop/golang.csv
1 skip
2 ng_entry failed("cannot get URL")
3 ok_entry ok
```